### PR TITLE
LPS-21585 Documents and Media - Firefox 3 - Xuggler video preview does not display when viewing a video

### DIFF
--- a/portal-web/docroot/html/css/portal/preview.css
+++ b/portal-web/docroot/html/css/portal/preview.css
@@ -24,10 +24,6 @@
 	max-width: 100%;
 }
 
-.lfr-preview-video-content div.aui-video-node {
-	height: 100%;
-}
-
 .lfr-preview-file-image-current-column, .lfr-preview-file-video-current-column {
 	padding: 20px;
 	position: relative;
@@ -263,4 +259,8 @@
 		font-size: 398.2px;
 		line-height: 1;
 	}
+}
+
+.firefox .lfr-preview-video-content .aui-video-node {
+	height: 100%;
 }


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-21585

Robert,

See my changes and ensure you only target specific versions of Firefox as needed (v3.6, v20+). If it affects all version of Firefox you don't need to make any changes and can send this straight to Nate.

Thanks,

Byran
