### PR TITLE
LPS-38678 - Nav items items can be dragged outside of nav bar

### DIFF
--- a/portal-web/docroot/html/js/liferay/navigation.js
+++ b/portal-web/docroot/html/js/liferay/navigation.js
@@ -631,11 +631,11 @@ AUI.add(
 				var instance = this;
 
 				if (instance.get('isSortable')) {
-					var navBlock = instance.get('navBlock');
+					var navList = instance.get('navBlock').one('ul.nav');
 
 					var sortable = new A.Sortable(
 						{
-							container: navBlock,
+							container: navList,
 							moveType: 'move',
 							nodes: '.lfr-nav-sortable',
 							opacity: '.5',


### PR DESCRIPTION
Hey @Robert-Frampton,

Attached is an update for http://issues.liferay.com/browse/LPS-38678.  We need to update the navigation since it might not be using a .nav class. (in fact the navigation.vm in _unstyled doesn't use it).

Has this always broken? Because we've never needed to specify it before, so my guess is that either because the structure has changed that somewhere in the JS it's relying on the UI being a direct descendant of the navblock or there's something else going on.

But if we need to use a specific markup structure, we should allow the user to customize it the same way we do NAV_ITEM_SELECTOR (you can see in classic/_diffs/templates/navigation.vm at the bottom).

Please let me know if you have any questions.  Thanks!
