### PR TITLE
LPS-40665 - Mobile dockbar icons behave inconsistently 

### DIFF
--- a/portal-web/docroot/html/js/liferay/dockbar.js
+++ b/portal-web/docroot/html/js/liferay/dockbar.js
@@ -308,11 +308,11 @@ AUI.add(
 					dockBar.delegate(
 						EVENT_CLICK,
 						function(event) {
-							var isSiteNav = event.currentTarget.attr('data-navid') === (namespace + 'navSiteNavigation');
+							var currentTarget = event.currentTarget;
 
 							var open = btnNavigation.hasClass(STR_OPEN);
 
-							if (isSiteNav || open) {
+							if (open || (currentTarget === btnNavigation)) {
 								btnNavigation.toggleClass(STR_OPEN);
 								navigation.toggleClass(STR_OPEN);
 							}
@@ -397,7 +397,7 @@ AUI.add(
 					if (navAccountControlsAncestor) {
 						navLink = navAccountControlsAncestor.one('li a');
 					}
-
+					console.log(navLink);
 					navLink.blur();
 					navLink.focus();
 				}


### PR DESCRIPTION
Hey @Robert-Frampton,

Attached is an update for http://issues.liferay.com/browse/LPS-40665.  I have spoken with Nate and we would like to make some additional changes to this issue so that when the other dockbar icons (edit and admin) are "open", we would like them to have the blue highlighted state (see screenshot):

![welcome - liferay 2013-11-14 15-35-20](https://f.cloud.github.com/assets/860951/1546444/c4387e4a-4d85-11e3-98d2-ad6ce6700e5b.png)

The navigation will stay orange when it is "open".

Please let me know if you have any questions.  Thanks!
