### PR TITLE
LPS-43097 

### DIFF
--- a/portal-web/docroot/html/css/taglib/button.css
+++ b/portal-web/docroot/html/css/taglib/button.css
@@ -36,6 +36,10 @@
 				display: block;
 				margin-top: 5px;
 				width: 100%;
+
+				&.selector-button {
+					min-width: 100%;
+				}
 			}
 		}
 
@@ -55,7 +59,7 @@
 			border-bottom-width: 5px;
 		}
 
-		button.close, button.btn.close {
+		button.close, button.btn.close, button.btn.selector-button {
 			width: auto;
 		}
 	}


### PR DESCRIPTION
The choose button displays incomplete when the document title is too long.
