### PR TITLE
LPS-44348 iPad Scroll for MessageBoards & Bookmarks Portlet

### DIFF
--- a/portal-web/docroot/html/css/taglib/search_iterator.css
+++ b/portal-web/docroot/html/css/taglib/search_iterator.css
@@ -5,7 +5,7 @@
 	margin-top: 1.5em;
 	overflow: auto;
 
-	@include respond-to(phone, tablet) {
+	@media (max-width: 1024px) {
 		@include experimental(overflow-scrolling, touch);
 
 		.searchcontainer-content .table {


### PR DESCRIPTION
Found solution through similar ticket, https://issues.liferay.com/browse/LPP-10232. Tablet media query was breaking at 980px, landscape mode on iPad exceeds 980px.
