### PR TITLE
LPS-45911 aui:input type=file has a CSS max-width style which causes its...

### DIFF
--- a/portal-web/docroot/html/css/portal/forms.css
+++ b/portal-web/docroot/html/css/portal/forms.css
@@ -157,7 +157,7 @@
 
 .aui {
 	input[type=file] {
-		max-width: 220px;
+		width: 100%;
 	}
 
 	fieldset {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-45911
