### PR TITLE
LPS-48058

### DIFF
--- a/portal-web/docroot/html/js/liferay/util_window.js
+++ b/portal-web/docroot/html/js/liferay/util_window.js
@@ -68,15 +68,11 @@ AUI.add(
 					_getViewportRegion: function() {
 						var instance = this;
 
-						var viewportRegion = instance._viewportRegion;
-
-						if (!viewportRegion) {
-							viewportRegion = instance._posNode.get('viewportRegion');
-
-							instance._viewportRegion = viewportRegion;
+						if (!instance._viewportRegion) {
+							instance._viewportRegion = instance._posNode.get('viewportRegion');
 						}
 
-						return viewportRegion;
+						return instance._viewportRegion;
 					}
 				}
 			}


### PR DESCRIPTION
Hey @Robert-Frampton,

Attached is an update for http://issues.liferay.com/browse/LPS-48058.

Can we take a look to see if this issue only exists in Liferay or Alloy as well?  I think that AUI modals should be allowed to be positioned absolutely, which I imagine would trigger this issue. If that is the case, I think we should fix it there, or expose the getRegion method as being public so that we can complain if they change the API.

Nate is hesitant to push this fix in because we are extending a private method of an AUI component, but in reality, that makes things pretty fragile.

Can you take a look and see what we can find on the AUI side?

Please let me know if you have any questions.  Thanks!
