### PR TITLE
FreeMarkerServletResourceParser fix

### DIFF
--- a/modules/portal/portal-template-freemarker/src/com/liferay/portal/template/freemarker/FreeMarkerServletResourceParser.java
+++ b/modules/portal/portal-template-freemarker/src/com/liferay/portal/template/freemarker/FreeMarkerServletResourceParser.java
@@ -71,7 +71,7 @@ public class FreeMarkerServletResourceParser extends URLResourceParser {
 		URL url = servletContext.getResource(templateName);
 
 		if (url == null) {
-			url = PortalWebResourcesUtil.getResource(name);
+			url = PortalWebResourcesUtil.getResource(templateName);
 		}
 
 		if ((url == null) && templateName.endsWith("/init_custom.ftl")) {


### PR DESCRIPTION
cc @natecavanaugh

This change will allow at least the init files to be loaded correctly.  But the parsing of portal_normal.ftl is still failing.