### PR TITLE
[Technical Support] LPS-70366

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
@@ -379,6 +379,8 @@ public interface WebKeys {
 
 	public static final String PARALLEL_RENDERING_TIMEOUT_ERROR = "PARALLEL_RENDERING_TIMEOUT_ERROR";
 
+	public static final String PASSWORD_EXPIRATION_WARNING = "PASSWORD_EXPIRATION_WARNING";
+
 	public static final String PASSWORD_POLICY = "PASSWORD_POLICY";
 
 	public static final String PHONE = "PHONE";

--- a/portal-web/docroot/html/common/themes/password_expiring_soon.jspf
+++ b/portal-web/docroot/html/common/themes/password_expiring_soon.jspf
@@ -19,11 +19,11 @@
 		<aui:script use="liferay-alert">
 			new Liferay.Notification(
 				{
-					message: '<liferay-ui:message key="warning-your-password-will-expire-soon" />',
 					closeable: true,
 					destroyOnHide: false,
-					type: 'warning',
-					render: true
+					message: '<liferay-ui:message key="warning-your-password-will-expire-soon" />',
+					render: true,
+					type: 'warning'
 				}
 			);
 		</aui:script>

--- a/portal-web/docroot/html/common/themes/password_expiring_soon.jspf
+++ b/portal-web/docroot/html/common/themes/password_expiring_soon.jspf
@@ -15,13 +15,28 @@
 --%>
 
 <c:if test="<%= themeDisplay.isSignedIn() && UserLocalServiceUtil.isPasswordExpiringSoon(user) %>">
-	<aui:script use="liferay-notice">
-		new Liferay.Notice(
-			{
-				closeText: '<liferay-ui:message key="close" />',
-				content: '<liferay-ui:message key="warning-your-password-will-expire-soon" />',
-				toggleText: false
-			}
-		);
-	</aui:script>
+
+	<%
+	Boolean passwordReminder = Validator.isNull(session.getAttribute("PASSWORD-REMINDER"));
+	%>
+
+	<c:if test="<%= passwordReminder %>">
+		<aui:script use="liferay-alert">
+			new Liferay.Notification(
+				{
+					message: '<liferay-ui:message key="warning-your-password-will-expire-soon" />',
+					closeable: true,
+					destroyOnHide: false,
+					type: 'warning',
+					render: true
+				}
+			);
+		</aui:script>
+
+		<%
+		session.setAttribute("PASSWORD-REMINDER", true);
+		%>
+
+	</c:if>
+
 </c:if>

--- a/portal-web/docroot/html/common/themes/password_expiring_soon.jspf
+++ b/portal-web/docroot/html/common/themes/password_expiring_soon.jspf
@@ -15,12 +15,7 @@
 --%>
 
 <c:if test="<%= themeDisplay.isSignedIn() && UserLocalServiceUtil.isPasswordExpiringSoon(user) %>">
-
-	<%
-	Boolean passwordReminder = Validator.isNull(session.getAttribute("PASSWORD-REMINDER"));
-	%>
-
-	<c:if test="<%= passwordReminder %>">
+	<c:if test="<%= Validator.isNull((Boolean)session.getAttribute(WebKeys.PASSWORD_EXPIRATION_WARNING)) %>">
 		<aui:script use="liferay-alert">
 			new Liferay.Notification(
 				{
@@ -34,9 +29,8 @@
 		</aui:script>
 
 		<%
-		session.setAttribute("PASSWORD-REMINDER", true);
+		session.setAttribute(WebKeys.PASSWORD_EXPIRATION_WARNING, true);
 		%>
 
 	</c:if>
-
 </c:if>


### PR DESCRIPTION
/cc @NolanChan

Hey @Robert-Frampton,

Here's an update for https://issues.liferay.com/browse/LPS-70366.

For this fix, I think was we're looking for is the following:
1. Only one password expiration warning notification shows on the page.
2. When the user closes the notification, the notification stays closed for the whole session, even when a use navigates away from the portal without logging out and then navigates back.
3. The notification should reappear when a user logs out and logs back in.

From Nolan:

> The problems that I'm trying to address in this PR are twofold:
> 
> 1. Notice.js was formatting itself really badly in DXP, and given that it's deprecated I opted to move this code over to Notification.js
> 
> 2. Brian and Tsubasa are concerned that the repetitive nature of the password notifications will be extremely annoying, to which I agree. I looked to see if session.js could be of some use, but the functionality wasn't helpful once I understood what it was doing. I settled on using the browser's session to track whether the user has seen the notification, which mimics a lenient number of times for this notification to be shown to the customer. I'm open to brainstorming to figuring out a better way.